### PR TITLE
ruby gem to fix same-site cookies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,3 +123,7 @@ gem 'immigrant'
 gem 'ims-lti', '~> 1.1.8'
 #Gems for OpenPOP support
 gem 'rest-client'
+
+# Gems for cookie updates
+gem 'user_agent_parser', '< 2.5.2' # 2.6 requires ruby 2.4
+gem 'rails_same_site_cookie'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -349,6 +349,9 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_same_site_cookie (0.1.8)
+      rack (>= 1.5)
+      user_agent_parser (~> 2.5)
     railties (4.2.11.3)
       actionpack (= 4.2.11.3)
       activesupport (= 4.2.11.3)
@@ -465,6 +468,7 @@ GEM
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
     unicode_utils (1.4.0)
+    user_agent_parser (2.5.1)
     wannabe_bool (0.7.1)
     warden (1.2.7)
       rack (>= 1.0)
@@ -536,6 +540,7 @@ DEPENDENCIES
   rabl
   rails (~> 4.2)
   rails-erd!
+  rails_same_site_cookie
   redcarpet
   remotipart
   representable (~> 2.1)
@@ -554,6 +559,7 @@ DEPENDENCIES
   truncate_html
   tzinfo
   uglifier (>= 1.3.0)
+  user_agent_parser (< 2.5.2)
   wannabe_bool
 
 BUNDLED WITH


### PR DESCRIPTION
OpenDSA is unable to pass the correct information to CodeWorkout to load assignments because the CodeWorkout cookie does not have the correct attributes set after recent updates to Chrome and incoming updates to other browsers.  According to the link below, cookies need to be set to SameSite=None and Secure=True in order to work correctly.  These gems handle this issue and the user_agent_parser can be used to change cookie settings based on browser if necessary (this hasn't been in OpenDSA).  

https://www.imsglobal.org/samesite-cookie-issues-lti-tool-providers

